### PR TITLE
Revert "build(deps): bump prost from 0.12.0 to 0.12.1 (#156)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "aa8473a65b88506c106c28ae905ca4a2b83a2993640467a41bb3080627ddfd2c"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "56075c27b20ae524d00f247b8a4dc333e5784f889fe63099f8e626bc8d73486c"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",

--- a/exon/Cargo.toml
+++ b/exon/Cargo.toml
@@ -29,7 +29,7 @@ num_cpus = "1.16.0"
 object_store = {workspace = true}
 parking_lot = "0.12.1"
 pin-project = {version = "1.1.3", optional = true}
-prost = {version = "0.12.1", optional = true}
+prost = {version = "0.12.0", optional = true}
 quick-xml = {version = "0.30.0", features = ["async-tokio", "serialize", "overlapped-lists"], optional = true}
 serde = {version = "1", features = ["derive"], optional = true}
 tokio = {version = "1", features = ["io-util"]}


### PR DESCRIPTION
This reverts commit 341c200ab929386c0b1e6cbc26b9fbe1e027fcf2.