### PR TITLE
refactor: add exon fasta error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ lto = true
 [profile.profiling]
 debug = true
 inherits = "release"
+
+[profile.quick-bench]
+debug = true
+inherits = "release"
+lto = false

--- a/exon/exon-core/src/config/mod.rs
+++ b/exon/exon-core/src/config/mod.rs
@@ -19,7 +19,7 @@ use datafusion::{
 };
 
 pub const BATCH_SIZE: usize = 8 * 1024;
-pub const FASTA_READER_SEQUENCE_CAPACITY: usize = 384;
+pub const FASTA_READER_SEQUENCE_CAPACITY: usize = 512;
 
 /// Create a new [`SessionConfig`] for the exon.
 pub fn new_exon_config() -> SessionConfig {

--- a/exon/exon-core/src/datasources/fasta/file_opener.rs
+++ b/exon/exon-core/src/datasources/fasta/file_opener.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use arrow::error::ArrowError;
 use datafusion::{
     datasource::{
         file_format::file_compression_type::FileCompressionType,
@@ -61,7 +62,9 @@ impl FileOpener for FASTAOpener {
 
             let stream_reader = StreamReader::new(new_reader);
 
-            let fasta_batch_reader = BatchReader::new(stream_reader, fasta_config).into_stream();
+            let fasta_batch_reader = BatchReader::new(stream_reader, fasta_config)
+                .into_stream()
+                .map_err(ArrowError::from);
 
             Ok(fasta_batch_reader.boxed())
         }))

--- a/exon/exon-core/src/datasources/vcf/file_opener/indexed_file_opener.rs
+++ b/exon/exon-core/src/datasources/vcf/file_opener/indexed_file_opener.rs
@@ -31,6 +31,7 @@ use tokio_util::io::StreamReader;
 
 use crate::{
     datasources::vcf::{indexed_async_batch_stream::IndexedAsyncBatchStream, VCFConfig},
+    error::ExonError,
     streaming_bgzf::AsyncBGZFReader,
 };
 
@@ -149,14 +150,8 @@ impl FileOpener for IndexedVCFOpener {
                         // reading from a block boundary.
                         if vp_start.uncompressed() > 0 {
                             let marginal_start_vp =
-                                VirtualPosition::try_from((0, vp_start.uncompressed())).map_err(
-                                    |e| {
-                                        std::io::Error::new(
-                                            std::io::ErrorKind::InvalidData,
-                                            format!("invalid virtual position: {e}"),
-                                        )
-                                    },
-                                )?;
+                                VirtualPosition::try_from((0, vp_start.uncompressed()))
+                                    .map_err(ExonError::from)?;
 
                             async_reader
                                 .scan_to_virtual_position(marginal_start_vp)

--- a/exon/exon-core/src/error/mod.rs
+++ b/exon/exon-core/src/error/mod.rs
@@ -16,6 +16,7 @@ use std::{error::Error, fmt::Display};
 
 use arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
+use noodles::bgzf::virtual_position::TryFromU64U16TupleError;
 
 /// Error for an invalid region.
 pub mod invalid_region;
@@ -75,6 +76,12 @@ impl From<std::io::Error> for ExonError {
 impl From<object_store::Error> for ExonError {
     fn from(error: object_store::Error) -> Self {
         ExonError::ObjectStoreError(error)
+    }
+}
+
+impl From<TryFromU64U16TupleError> for ExonError {
+    fn from(_error: TryFromU64U16TupleError) -> Self {
+        ExonError::ExecutionError("Error creating virtual position".to_string())
     }
 }
 

--- a/exon/exon-fasta/src/error.rs
+++ b/exon/exon-fasta/src/error.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 WHERE TRUE Technologies.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error::Error, fmt::Display};
+
+use arrow::error::ArrowError;
+
+#[derive(Debug)]
+pub enum ExonFastaError {
+    InvalidDefinition(String),
+    InvalidRecord(String),
+    ArrowError(ArrowError),
+    IOError(std::io::Error),
+    ParseError(String),
+}
+
+impl Display for ExonFastaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExonFastaError::InvalidDefinition(msg) => write!(f, "Invalid definition: {}", msg),
+            ExonFastaError::InvalidRecord(msg) => write!(f, "Invalid record: {}", msg),
+            ExonFastaError::ArrowError(error) => write!(f, "Arrow error: {}", error),
+            ExonFastaError::IOError(error) => write!(f, "IO error: {}", error),
+            ExonFastaError::ParseError(msg) => write!(f, "Parse error: {}", msg),
+        }
+    }
+}
+
+impl Error for ExonFastaError {}
+
+impl From<std::io::Error> for ExonFastaError {
+    fn from(error: std::io::Error) -> Self {
+        ExonFastaError::IOError(error)
+    }
+}
+
+impl From<noodles::fasta::record::definition::ParseError> for ExonFastaError {
+    fn from(error: noodles::fasta::record::definition::ParseError) -> Self {
+        ExonFastaError::ParseError(error.to_string())
+    }
+}
+
+impl From<ArrowError> for ExonFastaError {
+    fn from(error: ArrowError) -> Self {
+        ExonFastaError::ArrowError(error)
+    }
+}
+
+impl From<ExonFastaError> for ArrowError {
+    fn from(error: ExonFastaError) -> Self {
+        ArrowError::ExternalError(Box::new(error))
+    }
+}
+
+pub type ExonFastaResult<T, E = ExonFastaError> = std::result::Result<T, E>;

--- a/exon/exon-fasta/src/lib.rs
+++ b/exon/exon-fasta/src/lib.rs
@@ -15,8 +15,10 @@
 mod array_builder;
 mod batch_reader;
 mod config;
+mod error;
 
 pub use array_builder::FASTAArrayBuilder;
 pub use batch_reader::BatchReader;
 pub use config::new_fasta_schema_builder;
 pub use config::FASTAConfig;
+pub use error::ExonFastaError;


### PR DESCRIPTION
* adds a new fasta error
* "quick-bench" profile for profiling w/o `lto`