### PR TITLE
chore(cargo): inherit `repository` in exon and exon-io

### DIFF
--- a/exon/exon-core/Cargo.toml
+++ b/exon/exon-core/Cargo.toml
@@ -3,6 +3,7 @@ description = "A platform for scientific data processing and analysis."
 edition = "2021"
 exclude = ["test-data/*"]
 homepage = { workspace = true }
+repository = { workspace = true }
 keywords = ["biology", "science", "arrow"]
 license = { workspace = true }
 name = "exon"

--- a/exon/exon-io/Cargo.toml
+++ b/exon/exon-io/Cargo.toml
@@ -2,6 +2,7 @@
 description = "IO utilities for Exon."
 edition = "2021"
 homepage = { workspace = true }
+repository = { workspace = true }
 keywords = ["biology", "science", "arrow"]
 license = { workspace = true }
 name = "exon-io"


### PR DESCRIPTION
Inherit [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

This change only affects `exon` and `exon-io`. All other modules already correctly inherit repository.