### PR TITLE
feat(R): expose `to_record_batch_reader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.70.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c7777c4301ec50202f778c15d73b88c30f9240a074f9b9a98fe7babfa5bfc8"
+checksum = "2029b57a53b82f4f6de67b22995f2edf43013ca36d488f6d1ea45143aa69ab56"
 dependencies = [
  "noodles-bam",
  "noodles-bcf",
@@ -3271,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bam"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880f71c52dab49e073361e0427610e07eccea07ff48a2ecd8f133c648cb115d8"
+checksum = "786fd4a0c30579e2f0fa39edbe83f395e25848a8056cfdd9714665e664d11884"
 dependencies = [
  "bit-vec",
  "bstr",
@@ -3290,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bcf"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d58b4cf86ba61cecf9a26b598c2889a28ad7db4a2c0dc1bc5e2c6d7a1858305"
+checksum = "61db2b3babd0a266a1de2165f3fb74c884b3809a0da8a5562183e89e9387b083"
 dependencies = [
  "byteorder",
  "futures",
@@ -3315,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff82b0fb78c11947b29ef50e8ddf0093813fa9e613af0e13dc53fc12b2dc3ea"
+checksum = "7dba1c82e9f92c00b23538359e5d191dff7ccb300cf659ee3a835af65c3cd143"
 dependencies = [
  "byteorder",
  "bytes",
@@ -3337,9 +3337,9 @@ checksum = "7336c3be652de4e05444c9b12a32331beb5ba3316e8872d92bfdd8ef3b06c282"
 
 [[package]]
 name = "noodles-cram"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7ea5956fad57e0c09a0dc84bb0536606434ef82112035d113745215ba71ebc"
+checksum = "3c647b4ad9989372cacfa53aac15638d054d7243bcc7216abc0463d8fa89ce85"
 dependencies = [
  "async-compression",
  "bitflags 2.5.0",
@@ -3362,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938d7d865a3fbb079c7855e76eb1ef0be5d285dc039fa7776622225c7f708411"
+checksum = "857fcce273172c7ec188369c0e745e95aefc477a67262133862c9ef3375e56b9"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -3376,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-fasta"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f7006eff28b06d2c2b1129f9dd2ba637163b92068617060433f22f557e6ce2"
+checksum = "80fb1a1bd49879db277665dfc2a714de9afdd9ab231800adfb4e9a453d311ea5"
 dependencies = [
  "bytes",
  "memchr",
@@ -3400,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-gff"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9216634517bf888abb425b10f3df7857ee3f584d4e46c8d6a2bb2c84acc4e10e"
+checksum = "9f57b63192148435afc085900a7c5a5273bd959c066f9ef7310b7336093aafc7"
 dependencies = [
  "indexmap 2.2.6",
  "noodles-bgzf",
@@ -3413,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-gtf"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d4fabc2e574e80c00341685e8f4df37ae0b5a00a6fecccfd7c99eb45d5a4cf"
+checksum = "c148831e447f5d9517cad32ed6fe936eb87da9053174bef96134bdda0cab7cd6"
 dependencies = [
  "noodles-bgzf",
  "noodles-core",
@@ -3424,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-sam"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0598e959a0e56fc60f11b3bc63bf11c332a530cb54883196c0eab1bd0d4b8a"
+checksum = "50a3f7dd522280b5f4d72e0a66f9d0350c0f7f5b1c3a8cbc8ff6be6b28df9fa8"
 dependencies = [
  "bitflags 2.5.0",
  "bstr",
@@ -3442,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-tabix"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8678ba994f92170f6675ad9b839c0163ba10c866ef1a942e6ea83d4ec2ca052a"
+checksum = "778b5a8cfbe846c7239cdd9f3ba7b9e46a4d46d957822051ae16680713bbd028"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -3457,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-vcf"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010d7057634a154feaf4db8dcc50ef522f5ad7201b6b598e20fb53a5c19ecd3f"
+checksum = "ad890dd39fe923d22112ed0c90ed9835b2c196d6a4e711b20a007852ed63ced9"
 dependencies = [
  "futures",
  "indexmap 2.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ arrow = { version = "51.0.0" }
 async-trait = "0.1.80"
 datafusion = { version = "37", features = ["compression", "parquet"] }
 futures = "0.3"
-noodles = { version = "0.70" }
+noodles = { version = "0.71" }
 object_store = { version = "0.9" }
 tokio = { version = "1", features = ["io-util"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }

--- a/exon-r/exonr/R/main.R
+++ b/exon-r/exonr/R/main.R
@@ -190,12 +190,7 @@ ExonDataFrame <- R6Class("ExonDataFrame",
         #'
         #' @return An Arrow table.
         to_arrow = function() {
-            stream <- nanoarrow::nanoarrow_allocate_array_stream()
-            pointer_addr <- nanoarrow::nanoarrow_pointer_addr_chr(stream)
-
-            private$data_frame$to_arrow(pointer_addr)
-
-            record_batch_stream <- arrow::RecordBatchStreamReader$import_from_c(pointer_addr)
+            record_batch_stream <- self$to_record_batch_reader()
 
             arrow::arrow_table(record_batch_stream)
         },

--- a/exon-r/exonr/R/main.R
+++ b/exon-r/exonr/R/main.R
@@ -198,6 +198,17 @@ ExonDataFrame <- R6Class("ExonDataFrame",
             record_batch_stream <- arrow::RecordBatchStreamReader$import_from_c(pointer_addr)
 
             arrow::arrow_table(record_batch_stream)
+        },
+        #' @description Convert the ExonDataFrame a stream of record batches.
+        #'
+        #' @return A stream of record batches.
+        to_record_batch_reader = function() {
+            stream <- nanoarrow::nanoarrow_allocate_array_stream()
+            pointer_addr <- nanoarrow::nanoarrow_pointer_addr_chr(stream)
+
+            private$data_frame$to_arrow(pointer_addr)
+
+            arrow::RecordBatchStreamReader$import_from_c(pointer_addr)
         }
     ),
     private = list(

--- a/exon-r/exonr/man/ExonDataFrame.Rd
+++ b/exon-r/exonr/man/ExonDataFrame.Rd
@@ -11,6 +11,7 @@ An ExonDataFrame is a data frame that is backed by an Exon engine.
 \itemize{
 \item \href{#method-ExonDataFrame-new}{\code{ExonDataFrame$new()}}
 \item \href{#method-ExonDataFrame-to_arrow}{\code{ExonDataFrame$to_arrow()}}
+\item \href{#method-ExonDataFrame-to_record_batch_reader}{\code{ExonDataFrame$to_record_batch_reader()}}
 \item \href{#method-ExonDataFrame-clone}{\code{ExonDataFrame$clone()}}
 }
 }
@@ -42,6 +43,19 @@ Convert the ExonDataFrame to an Arrow table.
 
 \subsection{Returns}{
 An Arrow table.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ExonDataFrame-to_record_batch_reader"></a>}}
+\if{latex}{\out{\hypertarget{method-ExonDataFrame-to_record_batch_reader}{}}}
+\subsection{Method \code{to_record_batch_reader()}}{
+Convert the ExonDataFrame a stream of record batches.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ExonDataFrame$to_record_batch_reader()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+A stream of record batches.
 }
 }
 \if{html}{\out{<hr>}}

--- a/exon/exon-bam/src/indexed_async_batch_stream.rs
+++ b/exon/exon-bam/src/indexed_async_batch_stream.rs
@@ -169,7 +169,7 @@ where
 
     async fn read_record(&mut self, record: &mut RecordBuf) -> std::io::Result<Option<()>> {
         if let Some(max_bytes) = self.max_bytes {
-            if self.reader.virtual_position().uncompressed() >= max_bytes {
+            if self.reader.get_ref().virtual_position().uncompressed() >= max_bytes {
                 return Ok(None);
             }
         }

--- a/exon/exon-core/src/datasources/bam/indexed_file_opener.rs
+++ b/exon/exon-core/src/datasources/bam/indexed_file_opener.rs
@@ -59,7 +59,7 @@ impl FileOpener for IndexedBAMOpener {
             let mut first_bam_reader = noodles::bam::AsyncReader::new(stream_reader);
 
             let header = first_bam_reader.read_header().await?;
-            let header_offset = first_bam_reader.virtual_position();
+            let header_offset = first_bam_reader.get_ref().virtual_position();
 
             let offsets = if let Some(ref ext) = file_meta.extensions {
                 ext.downcast_ref::<BGZFIndexedOffsets>()

--- a/exon/exon-core/src/datasources/vcf/file_opener/indexed_file_opener.rs
+++ b/exon/exon-core/src/datasources/vcf/file_opener/indexed_file_opener.rs
@@ -73,7 +73,7 @@ impl FileOpener for IndexedVCFOpener {
             // We save this header for later to pass to the batch reader for record deserialization.
             let header = vcf_reader.read_header().await?;
 
-            let header_offset = vcf_reader.virtual_position();
+            let header_offset = vcf_reader.get_ref().virtual_position();
 
             let batch_stream = match file_meta.extensions {
                 Some(ref ext) => {
@@ -193,8 +193,8 @@ impl FileOpener for IndexedVCFOpener {
                     let mut async_reader = AsyncBGZFReader::from_reader(stream_reader);
 
                     // If we're at the start of the file, we need to seek to the header offset.
-                    if vcf_reader.virtual_position().compressed() == 0
-                        && vcf_reader.virtual_position().uncompressed() == 0
+                    if vcf_reader.get_ref().virtual_position().compressed() == 0
+                        && vcf_reader.get_ref().virtual_position().uncompressed() == 0
                     {
                         tracing::debug!("Seeking to header offset: {:?}", header_offset);
                         async_reader.scan_to_virtual_position(header_offset).await?;

--- a/exon/exon-vcf/src/indexed_async_batch_stream.rs
+++ b/exon/exon-vcf/src/indexed_async_batch_stream.rs
@@ -72,7 +72,7 @@ where
     }
 
     async fn read_record(&mut self) -> std::io::Result<Option<noodles::vcf::Record>> {
-        if self.reader.virtual_position().uncompressed() as usize >= self.max_bytes {
+        if self.reader.get_ref().virtual_position().uncompressed() as usize >= self.max_bytes {
             return Ok(None);
         }
 


### PR DESCRIPTION
Exposes `to_record_batch_reader` on the result object so its contents can be streamed to other arrow compatible tools.

https://github.com/wheretrue/exon/issues/497